### PR TITLE
Fix Method:loadPlugins

### DIFF
--- a/monstache.go
+++ b/monstache.go
@@ -1169,7 +1169,7 @@ func (config *configOptions) loadPlugins() *configOptions {
 		if err == nil {
 			switch filter.(type) {
 			case func(*monstachemap.MapperPluginInput) (bool, error):
-				filterPlugin = mapper.(func(*monstachemap.MapperPluginInput) (bool, error))
+				filterPlugin = filter.(func(*monstachemap.MapperPluginInput) (bool, error))
 			default:
 				errorLog.Panicf("Plugin 'Filter' function must be typed %T", filterPlugin)
 			}


### PR DESCRIPTION
Fix a typo error that can cause golang plugin filter function not working.