### PR TITLE
Allow reflecting deletes on views

### DIFF
--- a/monstache.go
+++ b/monstache.go
@@ -884,7 +884,7 @@ func buildSelector(matchField string, data interface{}) bson.M {
 	return sel
 }
 
-func processRelated(client *mongo.Client, config *configOptions, root *gtm.Op, out *outputChans) (err error) {
+func processRelated(client *mongo.Client,bulk *elastic.BulkProcessor, elastic *elastic.Client,  config *configOptions, root *gtm.Op, out *outputChans) (err error) {
 	var q []*gtm.Op
 	batch := []*gtm.Op{root}
 	depth := 1
@@ -901,6 +901,22 @@ func processRelated(client *mongo.Client, config *configOptions, root *gtm.Op, o
 			for _, r := range rs {
 				if r.MaxDepth > 0 && r.MaxDepth < depth {
 					continue
+				}
+				if(op.IsDelete() && r.SrcField == "_id" && r.MatchField == "_id"){
+					rop := &gtm.Op{
+						Id:        op.Id,
+						Operation: op.Operation,
+						Namespace: r.WithNamespace,
+						Source:    op.Source,
+						Timestamp: op.Timestamp,
+					}
+					select {
+						case out.relateC <- rop:
+					default:
+						errorLog.Printf(relateQueueOverloadMsg, rop.Namespace, rop.Id)
+					}
+					doDelete(config, elastic, client, bulk, rop)
+					continue;
 				}
 				var srcData interface{}
 				if srcData, err = extractData(r.SrcField, op.Data); err != nil {
@@ -3935,7 +3951,7 @@ func main() {
 			go func() {
 				defer relateWg.Done()
 				for op := range outputChs.relateC {
-					if err := processRelated(mongoClient, config, op, outputChs); err != nil {
+					if err := processRelated(mongoClient, bulk, elasticClient, config, op, outputChs); err != nil {
 						processErr(err, config)
 					}
 				}

--- a/monstache.go
+++ b/monstache.go
@@ -884,7 +884,7 @@ func buildSelector(matchField string, data interface{}) bson.M {
 	return sel
 }
 
-func processRelated(client *mongo.Client,bulk *elastic.BulkProcessor, elastic *elastic.Client,  config *configOptions, root *gtm.Op, out *outputChans) (err error) {
+func processRelated(client *mongo.Client,bulk *elastic.BulkProcessor, elastic *elastic.Client, config *configOptions, root *gtm.Op, out *outputChans) (err error) {
 	var q []*gtm.Op
 	batch := []*gtm.Op{root}
 	depth := 1
@@ -910,12 +910,12 @@ func processRelated(client *mongo.Client,bulk *elastic.BulkProcessor, elastic *e
 						Source:    op.Source,
 						Timestamp: op.Timestamp,
 					}
+					doDelete(config, elastic, client, bulk, rop)
 					select {
 						case out.relateC <- rop:
 					default:
 						errorLog.Printf(relateQueueOverloadMsg, rop.Namespace, rop.Id)
 					}
-					doDelete(config, elastic, client, bulk, rop)
 					continue;
 				}
 				var srcData interface{}

--- a/monstache.go
+++ b/monstache.go
@@ -917,13 +917,10 @@ func processRelated(client *mongo.Client,bulk *elastic.BulkProcessor, elastic *e
 						Namespace: r.WithNamespace,
 						Source:    op.Source,
 						Timestamp: op.Timestamp,
+						Data:      op.Data,
 					}
 					doDelete(config, elastic, client, bulk, rop)
-					select {
-						case out.relateC <- rop:
-					default:
-						errorLog.Printf(relateQueueOverloadMsg, rop.Namespace, rop.Id)
-					}
+					q = append(q, rop);
 					continue;
 				}
 				var srcData interface{}
@@ -2683,7 +2680,6 @@ func doIndexing(config *configOptions, mongo *mongo.Client, bulk *elastic.BulkPr
 }
 
 func doIndex(config *configOptions, mongo *mongo.Client, bulk *elastic.BulkProcessor, client *elastic.Client, op *gtm.Op) (err error) {
-	fmt.Println("op",op.Namespace,op.Id,op.IsDelete(),op.Data);
 	if err = mapData(mongo, config, op); err == nil {
 		if op.Data != nil {
 			err = doIndexing(config, mongo, bulk, client, op)

--- a/monstache.go
+++ b/monstache.go
@@ -303,6 +303,14 @@ type configOptions struct {
 	mongoClientOptions       *options.ClientOptions
 }
 
+func (rel *relation) IsIdentity() bool {
+	if(rel.SrcField == "_id" && rel.MatchField == "_id"){
+		return true;
+	}else{
+		return false;
+	}
+}
+
 func (l *logFiles) enabled() bool {
 	return l.Info != "" || l.Warn != "" || l.Error != "" || l.Trace != "" || l.Stats != ""
 }
@@ -902,7 +910,7 @@ func processRelated(client *mongo.Client,bulk *elastic.BulkProcessor, elastic *e
 				if r.MaxDepth > 0 && r.MaxDepth < depth {
 					continue
 				}
-				if(op.IsDelete() && r.SrcField == "_id" && r.MatchField == "_id"){
+				if(op.IsDelete() && r.IsIdentity()){
 					rop := &gtm.Op{
 						Id:        op.Id,
 						Operation: op.Operation,
@@ -2675,6 +2683,7 @@ func doIndexing(config *configOptions, mongo *mongo.Client, bulk *elastic.BulkPr
 }
 
 func doIndex(config *configOptions, mongo *mongo.Client, bulk *elastic.BulkProcessor, client *elastic.Client, op *gtm.Op) (err error) {
+	fmt.Println("op",op.Namespace,op.Id,op.IsDelete(),op.Data);
 	if err = mapData(mongo, config, op); err == nil {
 		if op.Data != nil {
 			err = doIndexing(config, mongo, bulk, client, op)


### PR DESCRIPTION
HI @rwynn ,

This PR adds the functionality for Delete operations to reflect  one-to-one withNamspaces (name-spaces that are a view of the original  collection) 

Example of what I'm trying to achieve:
```
[[mapping]]
namespace="db.tableView"
index = "table_view"
type = "table_view"
[[relate]]
	namespace="db.originalTable"
	with-namespace="db.tableView"
	src-field="_id"
	match-field="_id"
```
Deletes on the originalTable should apply to the table_view index

Thanks.