### PR TITLE
/instance route, that get info about instance activity and cluster params

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ a go daemon that syncs mongodb to elasticsearch in realtime
 
 - Systemd support
 
-- Optional http server to get access to liveness, stats, etc
+- Optional http server to get access to liveness, stats, instance(for cluster mode) etc
 
 ### Documentation
 


### PR DESCRIPTION
When we use monstache daemon in cluster mode, sometimes we need to collect metrics about instances activity and params . It will help us with health check of indexing  and operative reaction for problems.
Now we have route /instance, here example of output:
```javascript
{
"Enabled": true,
"Pid": 33833,
"Hostname": "MacBook-Pro-NIKOLAY.org",
"ClusterName": "kola-es7-ion.hd.dev.kz",
"ResumeName": "kola-es7-ion.hd.dev.kz"
}
```