### PR TITLE
Add ability to read environment variables value from files

### DIFF
--- a/monstache.go
+++ b/monstache.go
@@ -2058,6 +2058,13 @@ func (config *configOptions) loadEnvironment() *configOptions {
 		if val == "" {
 			continue
 		}
+		if strings.HasSuffix(name, "__FILE") {
+			var err error
+			name, val, err = config.loadVariableValueFromFile(name, val)
+			if err != nil {
+				panic(err)
+			}
+		}
 		switch name {
 		case "MONSTACHE_MONGO_URL":
 			if config.MongoURL == "" {
@@ -2204,6 +2211,20 @@ func (config *configOptions) loadEnvironment() *configOptions {
 		}
 	}
 	return config
+}
+
+func (config *configOptions) loadVariableValueFromFile(name string, path string) (n string, v string, err error) {
+		name = strings.TrimSuffix(name, "__FILE")
+		f, err := os.Open(path)
+		if err != nil {
+			return name, "", fmt.Errorf("read value for %s from file failed: %s", name, err)
+		}
+		defer f.Close()
+		c, err := ioutil.ReadAll(f)
+		if err != nil {
+			return name, "", fmt.Errorf("read value for %s from file failed: %s", name, err)
+		}
+		return name, string(c), nil
 }
 
 func (config *configOptions) loadRoutingNamespaces() *configOptions {


### PR DESCRIPTION
**Use case**:
For using docker swarm/k8s secrets with monstache

**Example**:
```yaml
version: "3.7"
services:
  monstache:
    image: rwynn/monstache:5.6.0
    secrets:
      - mounstache_elasticsearch_password
      - mounstache_mongodb_url
    environment:
      MONSTACHE_ES_PASS__FILE: '/run/secrets/mounstache_elasticsearch_password' 
      MONSTACHE_MONGO_URL__FILE: '/run/secrets/mounstache_mongodb_url' 


secrets:
  mounstache_elasticsearch_password:
    external: true
  mounstache_mongodb_url:
    external: true
```