### PR TITLE
Added an option to automatically select an earliest oplog resume timestamp

### DIFF
--- a/monstache.go
+++ b/monstache.go
@@ -4594,7 +4594,7 @@ func (ic *indexClient) startListen() {
 		if config.ResumeFromEarliestTimestamp {
 			ic.oplogTsResolver = oplog.NewTimestampResolverEarliest(len(conns), infoLog)
 		} else {
-			ic.oplogTsResolver = oplog.TimestampResolverPolicySimple{}
+			ic.oplogTsResolver = oplog.TimestampResolverSimple{}
 		}
 	}
 

--- a/monstache.go
+++ b/monstache.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/rwynn/monstache/pkg/oplog"
 	"io/ioutil"
 	"log"
 	"math"
@@ -129,32 +130,33 @@ type buildInfo struct {
 type stringargs []string
 
 type indexClient struct {
-	gtmCtx      *gtm.OpCtxMulti
-	config      *configOptions
-	mongo       *mongo.Client
-	mongoConfig *mongo.Client
-	bulk        *elastic.BulkProcessor
-	bulkStats   *elastic.BulkProcessor
-	client      *elastic.Client
-	hsc         *httpServerCtx
-	fileWg      *sync.WaitGroup
-	indexWg     *sync.WaitGroup
-	processWg   *sync.WaitGroup
-	relateWg    *sync.WaitGroup
-	opsConsumed chan bool
-	closeC      chan bool
-	doneC       chan int
-	enabled     bool
-	lastTs      primitive.Timestamp
-	lastTsSaved primitive.Timestamp
-	tokens      bson.M
-	indexC      chan *gtm.Op
-	processC    chan *gtm.Op
-	fileC       chan *gtm.Op
-	relateC     chan *gtm.Op
-	filter      gtm.OpFilter
-	statusReqC  chan *statusRequest
-	sigH        *sigHandler
+	gtmCtx          *gtm.OpCtxMulti
+	config          *configOptions
+	mongo           *mongo.Client
+	mongoConfig     *mongo.Client
+	bulk            *elastic.BulkProcessor
+	bulkStats       *elastic.BulkProcessor
+	client          *elastic.Client
+	hsc             *httpServerCtx
+	fileWg          *sync.WaitGroup
+	indexWg         *sync.WaitGroup
+	processWg       *sync.WaitGroup
+	relateWg        *sync.WaitGroup
+	opsConsumed     chan bool
+	closeC          chan bool
+	doneC           chan int
+	enabled         bool
+	lastTs          primitive.Timestamp
+	lastTsSaved     primitive.Timestamp
+	tokens          bson.M
+	indexC          chan *gtm.Op
+	processC        chan *gtm.Op
+	fileC           chan *gtm.Op
+	relateC         chan *gtm.Op
+	filter          gtm.OpFilter
+	statusReqC      chan *statusRequest
+	sigH            *sigHandler
+	oplogTsResolver oplog.TimestampResolver
 }
 
 type sigHandler struct {
@@ -297,109 +299,110 @@ type statusRequest struct {
 }
 
 type configOptions struct {
-	EnableTemplate           bool
-	EnvDelimiter             string
-	MongoURL                 string         `toml:"mongo-url"`
-	MongoConfigURL           string         `toml:"mongo-config-url"`
-	MongoOpLogDatabaseName   string         `toml:"mongo-oplog-database-name"`
-	MongoOpLogCollectionName string         `toml:"mongo-oplog-collection-name"`
-	GtmSettings              gtmSettings    `toml:"gtm-settings"`
-	AWSConnect               awsConnect     `toml:"aws-connect"`
-	LogRotate                logRotate      `toml:"log-rotate"`
-	Logs                     logFiles       `toml:"logs"`
-	GraylogAddr              string         `toml:"graylog-addr"`
-	ElasticUrls              stringargs     `toml:"elasticsearch-urls"`
-	ElasticUser              string         `toml:"elasticsearch-user"`
-	ElasticPassword          string         `toml:"elasticsearch-password"`
-	ElasticPemFile           string         `toml:"elasticsearch-pem-file"`
-	ElasticValidatePemFile   bool           `toml:"elasticsearch-validate-pem-file"`
-	ElasticVersion           string         `toml:"elasticsearch-version"`
-	ElasticHealth0           int            `toml:"elasticsearch-healthcheck-timeout-startup"`
-	ElasticHealth1           int            `toml:"elasticsearch-healthcheck-timeout"`
-	ElasticPKIAuth           elasticPKIAuth `toml:"elasticsearch-pki-auth"`
-	ResumeName               string         `toml:"resume-name"`
-	NsRegex                  string         `toml:"namespace-regex"`
-	NsDropRegex              string         `toml:"namespace-drop-regex"`
-	NsExcludeRegex           string         `toml:"namespace-exclude-regex"`
-	NsDropExcludeRegex       string         `toml:"namespace-drop-exclude-regex"`
-	ClusterName              string         `toml:"cluster-name"`
-	Print                    bool           `toml:"print-config"`
-	Version                  bool
-	Pprof                    bool
-	EnableOplog              bool `toml:"enable-oplog"`
-	DisableChangeEvents      bool `toml:"disable-change-events"`
-	EnableEasyJSON           bool `toml:"enable-easy-json"`
-	Stats                    bool
-	IndexStats               bool   `toml:"index-stats"`
-	StatsDuration            string `toml:"stats-duration"`
-	StatsIndexFormat         string `toml:"stats-index-format"`
-	Gzip                     bool
-	Verbose                  bool
-	Resume                   bool
-	ResumeStrategy           resumeStrategy `toml:"resume-strategy"`
-	ResumeWriteUnsafe        bool           `toml:"resume-write-unsafe"`
-	ResumeFromTimestamp      int64          `toml:"resume-from-timestamp"`
-	Replay                   bool
-	DroppedDatabases         bool   `toml:"dropped-databases"`
-	DroppedCollections       bool   `toml:"dropped-collections"`
-	IndexFiles               bool   `toml:"index-files"`
-	IndexAsUpdate            bool   `toml:"index-as-update"`
-	FileHighlighting         bool   `toml:"file-highlighting"`
-	DisableFilePipelinePut   bool   `toml:"disable-file-pipeline-put"`
-	EnablePatches            bool   `toml:"enable-patches"`
-	FailFast                 bool   `toml:"fail-fast"`
-	IndexOplogTime           bool   `toml:"index-oplog-time"`
-	OplogTsFieldName         string `toml:"oplog-ts-field-name"`
-	OplogDateFieldName       string `toml:"oplog-date-field-name"`
-	OplogDateFieldFormat     string `toml:"oplog-date-field-format"`
-	ExitAfterDirectReads     bool   `toml:"exit-after-direct-reads"`
-	MergePatchAttr           string `toml:"merge-patch-attribute"`
-	ElasticMaxConns          int    `toml:"elasticsearch-max-conns"`
-	ElasticRetry             bool   `toml:"elasticsearch-retry"`
-	ElasticMaxDocs           int    `toml:"elasticsearch-max-docs"`
-	ElasticMaxBytes          int    `toml:"elasticsearch-max-bytes"`
-	ElasticMaxSeconds        int    `toml:"elasticsearch-max-seconds"`
-	ElasticClientTimeout     int    `toml:"elasticsearch-client-timeout"`
-	ElasticMajorVersion      int
-	ElasticMinorVersion      int
-	MaxFileSize              int64 `toml:"max-file-size"`
-	ConfigFile               string
-	Script                   []javascript
-	Filter                   []javascript
-	Pipeline                 []javascript
-	Mapping                  []indexMapping
-	Relate                   []relation
-	FileNamespaces           stringargs `toml:"file-namespaces"`
-	PatchNamespaces          stringargs `toml:"patch-namespaces"`
-	Workers                  stringargs
-	Worker                   string
-	ChangeStreamNs           stringargs     `toml:"change-stream-namespaces"`
-	DirectReadNs             stringargs     `toml:"direct-read-namespaces"`
-	DirectReadSplitMax       int            `toml:"direct-read-split-max"`
-	DirectReadConcur         int            `toml:"direct-read-concur"`
-	DirectReadNoTimeout      bool           `toml:"direct-read-no-timeout"`
-	DirectReadBounded        bool           `toml:"direct-read-bounded"`
-	DirectReadStateful       bool           `toml:"direct-read-stateful"`
-	DirectReadExcludeRegex   string         `toml:"direct-read-dynamic-exclude-regex"`
-	MapperPluginPath         string         `toml:"mapper-plugin-path"`
-	EnableHTTPServer         bool           `toml:"enable-http-server"`
-	HTTPServerAddr           string         `toml:"http-server-addr"`
-	TimeMachineNamespaces    stringargs     `toml:"time-machine-namespaces"`
-	TimeMachineIndexPrefix   string         `toml:"time-machine-index-prefix"`
-	TimeMachineIndexSuffix   string         `toml:"time-machine-index-suffix"`
-	TimeMachineDirectReads   bool           `toml:"time-machine-direct-reads"`
-	PipeAllowDisk            bool           `toml:"pipe-allow-disk"`
-	RoutingNamespaces        stringargs     `toml:"routing-namespaces"`
-	DeleteStrategy           deleteStrategy `toml:"delete-strategy"`
-	DeleteIndexPattern       string         `toml:"delete-index-pattern"`
-	ConfigDatabaseName       string         `toml:"config-database-name"`
-	FileDownloaders          int            `toml:"file-downloaders"`
-	RelateThreads            int            `toml:"relate-threads"`
-	RelateBuffer             int            `toml:"relate-buffer"`
-	PostProcessors           int            `toml:"post-processors"`
-	PruneInvalidJSON         bool           `toml:"prune-invalid-json"`
-	Debug                    bool
-	mongoClientOptions       *options.ClientOptions
+	EnableTemplate              bool
+	EnvDelimiter                string
+	MongoURL                    string         `toml:"mongo-url"`
+	MongoConfigURL              string         `toml:"mongo-config-url"`
+	MongoOpLogDatabaseName      string         `toml:"mongo-oplog-database-name"`
+	MongoOpLogCollectionName    string         `toml:"mongo-oplog-collection-name"`
+	GtmSettings                 gtmSettings    `toml:"gtm-settings"`
+	AWSConnect                  awsConnect     `toml:"aws-connect"`
+	LogRotate                   logRotate      `toml:"log-rotate"`
+	Logs                        logFiles       `toml:"logs"`
+	GraylogAddr                 string         `toml:"graylog-addr"`
+	ElasticUrls                 stringargs     `toml:"elasticsearch-urls"`
+	ElasticUser                 string         `toml:"elasticsearch-user"`
+	ElasticPassword             string         `toml:"elasticsearch-password"`
+	ElasticPemFile              string         `toml:"elasticsearch-pem-file"`
+	ElasticValidatePemFile      bool           `toml:"elasticsearch-validate-pem-file"`
+	ElasticVersion              string         `toml:"elasticsearch-version"`
+	ElasticHealth0              int            `toml:"elasticsearch-healthcheck-timeout-startup"`
+	ElasticHealth1              int            `toml:"elasticsearch-healthcheck-timeout"`
+	ElasticPKIAuth              elasticPKIAuth `toml:"elasticsearch-pki-auth"`
+	ResumeName                  string         `toml:"resume-name"`
+	NsRegex                     string         `toml:"namespace-regex"`
+	NsDropRegex                 string         `toml:"namespace-drop-regex"`
+	NsExcludeRegex              string         `toml:"namespace-exclude-regex"`
+	NsDropExcludeRegex          string         `toml:"namespace-drop-exclude-regex"`
+	ClusterName                 string         `toml:"cluster-name"`
+	Print                       bool           `toml:"print-config"`
+	Version                     bool
+	Pprof                       bool
+	EnableOplog                 bool `toml:"enable-oplog"`
+	DisableChangeEvents         bool `toml:"disable-change-events"`
+	EnableEasyJSON              bool `toml:"enable-easy-json"`
+	Stats                       bool
+	IndexStats                  bool   `toml:"index-stats"`
+	StatsDuration               string `toml:"stats-duration"`
+	StatsIndexFormat            string `toml:"stats-index-format"`
+	Gzip                        bool
+	Verbose                     bool
+	Resume                      bool
+	ResumeStrategy              resumeStrategy `toml:"resume-strategy"`
+	ResumeWriteUnsafe           bool           `toml:"resume-write-unsafe"`
+	ResumeFromTimestamp         int64          `toml:"resume-from-timestamp"`
+	ResumeFromEarliestTimestamp bool           `toml:"resume-from-earliest-timestamp"`
+	Replay                      bool
+	DroppedDatabases            bool   `toml:"dropped-databases"`
+	DroppedCollections          bool   `toml:"dropped-collections"`
+	IndexFiles                  bool   `toml:"index-files"`
+	IndexAsUpdate               bool   `toml:"index-as-update"`
+	FileHighlighting            bool   `toml:"file-highlighting"`
+	DisableFilePipelinePut      bool   `toml:"disable-file-pipeline-put"`
+	EnablePatches               bool   `toml:"enable-patches"`
+	FailFast                    bool   `toml:"fail-fast"`
+	IndexOplogTime              bool   `toml:"index-oplog-time"`
+	OplogTsFieldName            string `toml:"oplog-ts-field-name"`
+	OplogDateFieldName          string `toml:"oplog-date-field-name"`
+	OplogDateFieldFormat        string `toml:"oplog-date-field-format"`
+	ExitAfterDirectReads        bool   `toml:"exit-after-direct-reads"`
+	MergePatchAttr              string `toml:"merge-patch-attribute"`
+	ElasticMaxConns             int    `toml:"elasticsearch-max-conns"`
+	ElasticRetry                bool   `toml:"elasticsearch-retry"`
+	ElasticMaxDocs              int    `toml:"elasticsearch-max-docs"`
+	ElasticMaxBytes             int    `toml:"elasticsearch-max-bytes"`
+	ElasticMaxSeconds           int    `toml:"elasticsearch-max-seconds"`
+	ElasticClientTimeout        int    `toml:"elasticsearch-client-timeout"`
+	ElasticMajorVersion         int
+	ElasticMinorVersion         int
+	MaxFileSize                 int64 `toml:"max-file-size"`
+	ConfigFile                  string
+	Script                      []javascript
+	Filter                      []javascript
+	Pipeline                    []javascript
+	Mapping                     []indexMapping
+	Relate                      []relation
+	FileNamespaces              stringargs `toml:"file-namespaces"`
+	PatchNamespaces             stringargs `toml:"patch-namespaces"`
+	Workers                     stringargs
+	Worker                      string
+	ChangeStreamNs              stringargs     `toml:"change-stream-namespaces"`
+	DirectReadNs                stringargs     `toml:"direct-read-namespaces"`
+	DirectReadSplitMax          int            `toml:"direct-read-split-max"`
+	DirectReadConcur            int            `toml:"direct-read-concur"`
+	DirectReadNoTimeout         bool           `toml:"direct-read-no-timeout"`
+	DirectReadBounded           bool           `toml:"direct-read-bounded"`
+	DirectReadStateful          bool           `toml:"direct-read-stateful"`
+	DirectReadExcludeRegex      string         `toml:"direct-read-dynamic-exclude-regex"`
+	MapperPluginPath            string         `toml:"mapper-plugin-path"`
+	EnableHTTPServer            bool           `toml:"enable-http-server"`
+	HTTPServerAddr              string         `toml:"http-server-addr"`
+	TimeMachineNamespaces       stringargs     `toml:"time-machine-namespaces"`
+	TimeMachineIndexPrefix      string         `toml:"time-machine-index-prefix"`
+	TimeMachineIndexSuffix      string         `toml:"time-machine-index-suffix"`
+	TimeMachineDirectReads      bool           `toml:"time-machine-direct-reads"`
+	PipeAllowDisk               bool           `toml:"pipe-allow-disk"`
+	RoutingNamespaces           stringargs     `toml:"routing-namespaces"`
+	DeleteStrategy              deleteStrategy `toml:"delete-strategy"`
+	DeleteIndexPattern          string         `toml:"delete-index-pattern"`
+	ConfigDatabaseName          string         `toml:"config-database-name"`
+	FileDownloaders             int            `toml:"file-downloaders"`
+	RelateThreads               int            `toml:"relate-threads"`
+	RelateBuffer                int            `toml:"relate-buffer"`
+	PostProcessors              int            `toml:"post-processors"`
+	PruneInvalidJSON            bool           `toml:"prune-invalid-json"`
+	Debug                       bool
+	mongoClientOptions          *options.ClientOptions
 }
 
 func (eca elasticPKIAuth) enabled() bool {
@@ -1666,6 +1669,7 @@ func (config *configOptions) parseCommandLineFlags() *configOptions {
 	flag.BoolVar(&config.Resume, "resume", false, "True to capture the last timestamp of this run and resume on a subsequent run")
 	flag.Var(&config.ResumeStrategy, "resume-strategy", "Strategy to use for resuming. 0=timestamp,1=token")
 	flag.Int64Var(&config.ResumeFromTimestamp, "resume-from-timestamp", 0, "Timestamp to resume syncing from")
+	flag.BoolVar(&config.ResumeFromEarliestTimestamp, "resume-from-earliest-timestamp", false, "Automatically select an earliest timestamp to resume syncing from")
 	flag.BoolVar(&config.ResumeWriteUnsafe, "resume-write-unsafe", false, "True to speedup writes of the last timestamp synched for resuming at the cost of error checking")
 	flag.BoolVar(&config.Replay, "replay", false, "True to replay all events from the oplog and index them in elasticsearch")
 	flag.BoolVar(&config.IndexFiles, "index-files", false, "True to index gridfs files into elasticsearch. Requires the elasticsearch mapper-attachments (deprecated) or ingest-attachment plugin")
@@ -2146,6 +2150,9 @@ func (config *configOptions) loadConfigFile() *configOptions {
 		}
 		if config.ResumeFromTimestamp == 0 {
 			config.ResumeFromTimestamp = tomlConfig.ResumeFromTimestamp
+		}
+		if !config.ResumeFromEarliestTimestamp && tomlConfig.ResumeFromEarliestTimestamp {
+			config.ResumeFromEarliestTimestamp = true
 		}
 		if config.MergePatchAttr == "" {
 			config.MergePatchAttr = tomlConfig.MergePatchAttr
@@ -4376,7 +4383,7 @@ func (ic *indexClient) buildTimestampGen() gtm.TimestampGenerator {
 		}
 	} else if config.Resume {
 		after = func(client *mongo.Client, options *gtm.Options) (primitive.Timestamp, error) {
-			var ts primitive.Timestamp
+			var candidateTs primitive.Timestamp
 			var err error
 			col := client.Database(config.ConfigDatabaseName).Collection("monstache")
 			result := col.FindOne(context.Background(), bson.M{
@@ -4386,14 +4393,16 @@ func (ic *indexClient) buildTimestampGen() gtm.TimestampGenerator {
 				doc := make(map[string]interface{})
 				if err = result.Decode(&doc); err == nil {
 					if doc["ts"] != nil {
-						ts = doc["ts"].(primitive.Timestamp)
-						ts.I++
+						candidateTs = doc["ts"].(primitive.Timestamp)
+						candidateTs.I++
 					}
 				}
 			}
-			if ts.T == 0 {
-				ts, _ = gtm.LastOpTimestamp(client, options)
+			if candidateTs.T == 0 {
+				candidateTs, _ = gtm.LastOpTimestamp(client, options)
 			}
+
+			ts := <-ic.oplogTsResolver.GetResumeTimestamp(candidateTs)
 			infoLog.Printf("Resuming from timestamp %+v", ts)
 			return ts, nil
 		}
@@ -4579,8 +4588,18 @@ func (ic *indexClient) buildGtmOptions() *gtm.Options {
 
 func (ic *indexClient) startListen() {
 	config := ic.config
+	conns := ic.buildConnections()
+
+	if config.ResumeStrategy == timestampResumeStrategy {
+		if config.ResumeFromEarliestTimestamp {
+			ic.oplogTsResolver = oplog.NewTimestampResolverEarliest(len(conns), infoLog)
+		} else {
+			ic.oplogTsResolver = oplog.TimestampResolverPolicySimple{}
+		}
+	}
+
 	gtmOpts := ic.buildGtmOptions()
-	ic.gtmCtx = gtm.StartMulti(ic.buildConnections(), gtmOpts)
+	ic.gtmCtx = gtm.StartMulti(conns, gtmOpts)
 	if config.readShards() && !config.DisableChangeEvents {
 		ic.gtmCtx.AddShardListener(ic.mongoConfig, gtmOpts, config.makeShardInsertHandler())
 	}

--- a/pkg/oplog/timestamp_resolver.go
+++ b/pkg/oplog/timestamp_resolver.go
@@ -14,9 +14,9 @@ type TimestampResolver interface {
 }
 
 // A simple resolver immediately returns a timestamp it's been given.
-type TimestampResolverPolicySimple struct{}
+type TimestampResolverSimple struct{}
 
-func (r TimestampResolverPolicySimple) GetResumeTimestamp(candidateTs primitive.Timestamp) chan primitive.Timestamp {
+func (r TimestampResolverSimple) GetResumeTimestamp(candidateTs primitive.Timestamp) chan primitive.Timestamp {
 	tmpResultChan := make(chan primitive.Timestamp, 1)
 	tmpResultChan <- candidateTs
 

--- a/pkg/oplog/timestamp_resolver.go
+++ b/pkg/oplog/timestamp_resolver.go
@@ -1,0 +1,94 @@
+package oplog
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"log"
+	"sync"
+	"time"
+)
+
+// A TimestampResolver decides on a timestamp from which to start reading an oplog from.
+// A result may not be immediately available (see TimestampResolverEarliest), so it is returned in a channel.
+type TimestampResolver interface {
+	GetResumeTimestamp(candidateTs primitive.Timestamp) chan primitive.Timestamp
+}
+
+// A simple resolver immediately returns a timestamp it's been given.
+type TimestampResolverPolicySimple struct{}
+
+func (r TimestampResolverPolicySimple) GetResumeTimestamp(candidateTs primitive.Timestamp) chan primitive.Timestamp {
+	tmpResultChan := make(chan primitive.Timestamp, 1)
+	tmpResultChan <- candidateTs
+
+	return tmpResultChan
+}
+
+// TimestampResolverEarliest waits until oplog resume timestamps have been queried from all the available mongodb shards, and returns an earliest one.
+type TimestampResolverEarliest struct {
+	connectionsTotal   int
+	connectionsQueried int
+	currentTs          primitive.Timestamp
+	resultChan         chan primitive.Timestamp
+	logger             *log.Logger
+	m                  sync.Mutex
+}
+
+func NewTimestampResolverEarliest(connectionsTotal int, logger *log.Logger) *TimestampResolverEarliest {
+	return &TimestampResolverEarliest{
+		connectionsTotal: connectionsTotal,
+		resultChan:       make(chan primitive.Timestamp, connectionsTotal),
+		logger:           logger,
+	}
+}
+
+// Returns a channel from which an earliest resume timestamp can be received
+func (oplogResume *TimestampResolverEarliest) GetResumeTimestamp(candidateTs primitive.Timestamp) chan primitive.Timestamp {
+	oplogResume.m.Lock()
+	defer oplogResume.m.Unlock()
+
+	if oplogResume.connectionsQueried >= oplogResume.connectionsTotal {
+		// in this case, an earliest timestamp is already calculated,
+		// so it is just returned in a temporary channel
+		oplogResume.logger.Printf(
+			"Earliest oplog resume timestamp is already calculated: %s",
+			(time.Unix(int64(oplogResume.currentTs.T), 0)).Format(time.RFC3339),
+		)
+
+		tmpResultChan := make(chan primitive.Timestamp, 1)
+		tmpResultChan <- oplogResume.currentTs
+
+		return tmpResultChan
+	}
+
+	oplogResume.connectionsQueried++
+
+	// if a candidate timestamp is smaller than a currently known timestamp,
+	// then a current timestamp is updated
+	if oplogResume.currentTs.T == 0 || primitive.CompareTimestamp(candidateTs, oplogResume.currentTs) < 0 {
+		oplogResume.currentTs = candidateTs
+		oplogResume.logger.Printf(
+			"Oplog resume timestamp is updated: %s",
+			tsToTime(oplogResume.currentTs).Format(time.RFC3339),
+		)
+	}
+
+	// if this function has been called for every mongodb connection,
+	// then a final earliest resume timestamp can be returned to every caller
+	if oplogResume.connectionsQueried == oplogResume.connectionsTotal {
+		oplogResume.logger.Printf(
+			"Earliest oplog resume timestamp calculated: %s",
+			tsToTime(oplogResume.currentTs).Format(time.RFC3339),
+		)
+
+		for i := 0; i < oplogResume.connectionsTotal; i++ {
+			oplogResume.resultChan <- oplogResume.currentTs
+		}
+	}
+
+	return oplogResume.resultChan
+}
+
+// Converts a bson timestamp to go time.Time
+func tsToTime(ts primitive.Timestamp) time.Time {
+	return time.Unix(int64(ts.T), int64(ts.I))
+}

--- a/pkg/oplog/timestamp_resolver_test.go
+++ b/pkg/oplog/timestamp_resolver_test.go
@@ -1,0 +1,77 @@
+package oplog
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"log"
+	"os"
+	"testing"
+)
+
+// Tests an earliest timestamp resolver with 3 mongodb shards
+func TestTimestampResolverEarliest_GetResumeTimestamp_ThreeShards(t *testing.T) {
+	resolver := NewTimestampResolverEarliest(3, log.New(os.Stdout, "INFO ", log.Flags()))
+	timestampA := primitive.Timestamp{
+		T: 1000,
+		I: 10,
+	}
+	timestampB := primitive.Timestamp{
+		T: 1000,
+		I: 5,
+	}
+	timestampC := primitive.Timestamp{
+		T: 100500,
+		I: 100500,
+	}
+
+	chanA := resolver.GetResumeTimestamp(timestampA)
+	chanB := resolver.GetResumeTimestamp(timestampB)
+	chanC := resolver.GetResumeTimestamp(timestampC)
+
+	resultA := <-chanA
+	resultB := <-chanB
+	resultC := <-chanC
+
+	if resultA.T != 1000 || resultA.I != 5 {
+		t.Fatalf(
+			"Expected an earliest timestamp to be 1000.5, got %d.%d",
+			resultA.T,
+			resultA.I,
+		)
+	}
+
+	if !resultB.Equal(resultA) || !resultC.Equal(resultA) {
+		t.Fatalf(
+			"An earliest timestamp must be consistent for all callers",
+		)
+	}
+
+	repeatedCallResult := <-resolver.GetResumeTimestamp(primitive.Timestamp{
+		T: 1,
+		I: 1,
+	})
+	if !repeatedCallResult.Equal(resultA) {
+		t.Fatalf(
+			"A repeated call to GetResumeTimestamp must return a previously calculated timestamp; got %d.%d.",
+			repeatedCallResult.T,
+			repeatedCallResult.I,
+		)
+	}
+}
+
+// Tests an earliest timestamp resolver with a single mongodb shard
+func TestTimestampResolverEarliest_GetResumeTimestamp_SingleShard(t *testing.T) {
+	resolver := NewTimestampResolverEarliest(1, log.New(os.Stdout, "INFO ", log.Flags()))
+
+	result := <-resolver.GetResumeTimestamp(primitive.Timestamp{
+		T: 1000,
+		I: 3,
+	})
+
+	if result.T != 1000 || result.I != 3 {
+		t.Fatalf(
+			"Expected an earliest timestamp to be 1000.3, got %d.%d",
+			result.T,
+			result.I,
+		)
+	}
+}


### PR DESCRIPTION
This fixes a following problem:
1. Monstache is tailing an oplog of a sharded mongodb deployment.
2. Monstache is stopped due to a failure or for any other reason.
3. Upon restart, monstache has to pick up a resume timestamp.
If there are multiple shards, monstache will only store a last processed timestamp in one of them. So for some shards, an incorrect resume timestamp will be used, which leads to the updates being lost. 

In this PR the option is added to automatically select an earliest resume timestamp. The option is off by default and should not cause any compatibility issues.

I'm not sure this feature is ideologically correct (because maybe we should look for a root cause of why doesn't monstache keep its timestamps in every mongodb shard?). But it works in our case, and we'd like to avoid maintaining a fork of this project, so it would be great if we get this merged. Please let me know if you have any concerns or advice, I'd be happy to find a solution that works for everyone.
