### PR TITLE
AWS: Adding Webidentityprovider

### DIFF
--- a/monstache.go
+++ b/monstache.go
@@ -109,8 +109,8 @@ const (
 	awsCredentialStrategyFile
 	awsCredentialStrategyEnv
 	awsCredentialStrategyEndpoint
-	awsWebIdentityStrategy
 	awsCredentialStrategyChained
+	awsWebIdentityStrategy
 )
 
 type deleteStrategy int

--- a/monstache.go
+++ b/monstache.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"io/ioutil"
 	"log"
 	"math"
@@ -2948,6 +2949,7 @@ func (config *configOptions) NewHTTPClient() (client *http.Client, err error) {
 		} else if config.AWSConnect.Strategy == awsCredentialStrategyChained {
 			creds = credentials.NewChainCredentials([]credentials.Provider{
 				&credentials.EnvProvider{},
+				&stscreds.WebIdentityRoleProvider{},
 				&credentials.SharedCredentialsProvider{
 					Filename: config.AWSConnect.CredentialsFile,
 					Profile:  config.AWSConnect.Profile,

--- a/monstache.go
+++ b/monstache.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"io/ioutil"
 	"log"
 	"math"
@@ -30,6 +29,10 @@ import (
 	"syscall"
 	"text/template"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 
 	"github.com/rwynn/monstache/v6/pkg/oplog"
 
@@ -106,6 +109,7 @@ const (
 	awsCredentialStrategyFile
 	awsCredentialStrategyEnv
 	awsCredentialStrategyEndpoint
+	awsWebIdentityStrategy
 	awsCredentialStrategyChained
 )
 
@@ -2935,29 +2939,41 @@ func (config *configOptions) NewHTTPClient() (client *http.Client, err error) {
 	}
 	if config.AWSConnect.enabled() {
 		var creds *credentials.Credentials
+		var providers []credentials.Provider
 		if config.AWSConnect.Strategy == awsCredentialStrategyStatic {
 			creds = credentials.NewStaticCredentials(config.AWSConnect.AccessKey, config.AWSConnect.SecretKey, "")
-		} else if config.AWSConnect.Strategy == awsCredentialStrategyFile {
-			creds = credentials.NewCredentials(&credentials.SharedCredentialsProvider{
-				Filename: config.AWSConnect.CredentialsFile,
-				Profile:  config.AWSConnect.Profile,
-			})
-		} else if config.AWSConnect.Strategy == awsCredentialStrategyEnv {
-			creds = credentials.NewCredentials(&credentials.EnvProvider{})
-		} else if config.AWSConnect.Strategy == awsCredentialStrategyEndpoint {
-			creds = credentials.NewCredentials(defaults.RemoteCredProvider(*defaults.Config(), defaults.Handlers()))
-		} else if config.AWSConnect.Strategy == awsCredentialStrategyChained {
-			creds = credentials.NewChainCredentials([]credentials.Provider{
-				&credentials.EnvProvider{},
-				&stscreds.WebIdentityRoleProvider{},
-				&credentials.SharedCredentialsProvider{
+		} else {
+			if config.AWSConnect.Strategy == awsCredentialStrategyEnv || config.AWSConnect.Strategy == awsCredentialStrategyChained {
+				providers = append(providers, &credentials.EnvProvider{})
+			}
+			if config.AWSConnect.Strategy == awsCredentialStrategyFile || config.AWSConnect.Strategy == awsCredentialStrategyChained {
+				providers = append(providers, &credentials.SharedCredentialsProvider{
 					Filename: config.AWSConnect.CredentialsFile,
 					Profile:  config.AWSConnect.Profile,
-				},
-				defaults.RemoteCredProvider(*defaults.Config(), defaults.Handlers()),
-			})
+				})
+			}
+			if config.AWSConnect.Strategy == awsCredentialStrategyEndpoint || config.AWSConnect.Strategy == awsCredentialStrategyChained {
+				providers = append(providers, defaults.RemoteCredProvider(*defaults.Config(), defaults.Handlers()))
+			}
+			if config.AWSConnect.Strategy == awsWebIdentityStrategy || config.AWSConnect.Strategy == awsCredentialStrategyChained {
+				// Create a new session using the default AWS configuration
+				sess, err := session.NewSession()
+				if err != nil {
+					return nil, err
+				}
+				// Create a new STS client using the session
+				stsClient := sts.New(sess)
+				// Assume the IAM role associated with the pod using STS
+				roleProvider := stscreds.NewWebIdentityRoleProviderWithOptions(
+					stsClient,
+					os.Getenv("AWS_ROLE_ARN"),
+					"monstache",
+					stscreds.FetchTokenPath(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")),
+				)
+				providers = append(providers, roleProvider)
+			}
 		}
-		config.AWSConnect.creds = creds
+		config.AWSConnect.creds = credentials.NewChainCredentials(providers)
 		client = aws.NewV4SigningClientWithHTTPClient(creds, config.AWSConnect.Region, client)
 	}
 	return client, err


### PR DESCRIPTION
When running monstache in EKS, 
the recommended auth method is using IRSA (IAM Roles for service accounts).

Using this method of authentication will populate two ENV vars in your Pod, 
AWS_ROLE_ARN - the role to assume
AWS_WEB_IDENTITY_TOKEN_FILE - the token to do it with

To enable that, we need to also enable the stscreds.WebIdentityRoleProvider