### PR TITLE
Write direct read status on completion instead of shutdown

### DIFF
--- a/monstache.go
+++ b/monstache.go
@@ -4492,6 +4492,18 @@ func (ic *indexClient) startReadWait() {
 					ic.stopAllWorkers()
 					ic.doneC <- 30
 				}
+				return
+			}
+
+			if len(ic.config.DirectReadNs) > 0 {
+				ic.rwmutex.RLock()
+				infoLog.Println("Direct reads completed")
+				if ic.config.DirectReadStateful {
+					if err := ic.saveDirectReadNamespaces(); err != nil {
+						errorLog.Printf("Error saving direct read state: %s", err)
+					}
+				}
+				ic.rwmutex.RUnlock()
 			}
 		}()
 	}
@@ -5089,18 +5101,6 @@ func (ic *indexClient) closeClient() {
 	}
 	if ic.bulkStats != nil {
 		ic.bulkStats.Close()
-	}
-	if len(ic.config.DirectReadNs) > 0 {
-		ic.rwmutex.RLock()
-		if !ic.directReadsPending {
-			infoLog.Println("Direct reads completed")
-			if ic.config.DirectReadStateful {
-				if err := ic.saveDirectReadNamespaces(); err != nil {
-					errorLog.Printf("Error saving direct read state: %s", err)
-				}
-			}
-		}
-		ic.rwmutex.RUnlock()
 	}
 	close(ic.closeC)
 }


### PR DESCRIPTION
Hello! 
It would be nice if monstache had a signal for when direct reads has been completed, that can be detected by another process other than following the logs.

I propose to move the writing of direct read completion status to when it is completed, instead of shutdown.

This way another process could poll Monstache for the current replication status, and automate swithing indices for example.