### PR TITLE
Add new github workflow to build release binaries

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: latest
+          version: ~> 1.20
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,0 +1,33 @@
+name: Monstache release binaries
+
+on:
+  release:
+    types: [created]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+    contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v4
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v4
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d
         with:
           distribution: goreleaser
           version: ~> 1.20

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ _testmain.go
 
 # Swap files
 *.swp
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,38 @@
+before:
+  hooks:
+    - go mod download
+builds:
+- id: monstache
+  binary: monstache
+  env:
+  - CGO_ENABLED=0
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - amd64
+    - arm64
+archives:
+- id: monstache-archive
+  name_template: |-
+    monstache_{{ .Tag }}_{{ .Os }}_
+    {{- with .Arch -}}
+      {{- if (eq . "amd64") -}}x86_64
+      {{- else -}}{{- . -}}
+      {{- end -}}
+    {{ end }}
+    {{- with .Arm -}}
+      {{- if (eq . "6") -}}hf
+      {{- else -}}v{{- . -}}
+      {{- end -}}
+    {{- end -}}
+  builds:
+    - monstache
+  format_overrides:
+    - goos: windows
+      format: zip
+  files: ["LICENSE"]
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256


### PR DESCRIPTION
This is the first step to release monstache for multiple architectures. 
Goreleaser is used to automatically create and upload all the binaries.

Fixes #528 and also fixes #655

Also in the build I'm using CGO_ENABLED=0 to remove the dependency to musl/libc. I don't think you're using Cgo anywhere but feel free to double check and correct me if i'm wrong.

You can find an exemple here : https://github.com/adoy/monstache/releases/tag/1.0.2

Next step will be to automatically build docker images for multiple platforms (as there is only the amd64 one currently).