### PR TITLE
chore: use gridByteBuffer.String() instead

### DIFF
--- a/monstache.go
+++ b/monstache.go
@@ -1366,7 +1366,7 @@ func (ic *indexClient) addFileContent(op *gtm.Op) (err error) {
 	if err = encoder.Close(); err != nil {
 		return
 	}
-	op.Data["file"] = string(gridByteBuffer.Bytes())
+	op.Data["file"] = gridByteBuffer.String()
 	return
 }
 


### PR DESCRIPTION
use gridByteBuffer.String() instead of string(gridByteBuffer.Bytes())