### PR TITLE
Fix relation/indexing processing Data object collision

### DIFF
--- a/monstache.go
+++ b/monstache.go
@@ -1220,6 +1220,7 @@ func convertSrcDataToMatchFieldType(srcData interface{}, matchFieldType string) 
 
 func (ic *indexClient) processRelated(root *gtm.Op) (err error) {
 	var q []*gtm.Op
+	visited := map[interface{}]bool{}
 	batch := []*gtm.Op{root}
 	depth := 1
 	for len(batch) > 0 {
@@ -1232,6 +1233,7 @@ func (ic *indexClient) processRelated(root *gtm.Op) (err error) {
 			if len(rs) == 0 {
 				continue
 			}
+      		visited[op.Id] = true
 			for _, r := range rs {
 				if r.MaxDepth > 0 && r.MaxDepth < depth {
 					continue
@@ -1334,6 +1336,10 @@ func (ic *indexClient) processRelated(root *gtm.Op) (err error) {
 							if r2.MaxDepth < 1 || r2.MaxDepth >= (depth+1) {
 								visit = true
 							}
+						}
+						_, alreadyVisited := visited[rop.Id]
+						if alreadyVisited {
+							visit = false
 						}
 						if visit {
 							// Indexing mutates the operation "Data" object which breaks

--- a/monstache.go
+++ b/monstache.go
@@ -1233,7 +1233,7 @@ func (ic *indexClient) processRelated(root *gtm.Op) (err error) {
 			if len(rs) == 0 {
 				continue
 			}
-      		visited[op.Id] = true
+			visited[op.Id] = true
 			for _, r := range rs {
 				if r.MaxDepth > 0 && r.MaxDepth < depth {
 					continue


### PR DESCRIPTION
`processRelated` and `doIndex` may be executed for the same operation object, `doIndex` mutates the `Data` of the operation which breaks the relation processing if the relation processing happens after the indexing. 

The effect of such a collision may be observed as printed errors like "Source field _id not found in document: ...", because `doIndex` removes the `_id` field from the `Data` object as part of the `prepareDataForIndexing` function but `extractData` attempts to read it in case if the `src-field="_id"`

The fix separates copies of Data between relation processing and indexing, which eliminates the possibility of such a collision.