### PR TITLE
Bugfix: Load pipeline in mapping

### DIFF
--- a/monstache.go
+++ b/monstache.go
@@ -1923,7 +1923,7 @@ func (config *configOptions) loadIndexTypes() {
 				mapIndexTypes[m.Namespace] = &indexMapping{
 					Namespace: m.Namespace,
 					Index:     strings.ToLower(m.Index),
-					Pipeline:  m.Pipeline
+					Pipeline:  m.Pipeline,
 				}
 			} else {
 				errorLog.Fatalln("Mappings must specify namespace and index")

--- a/monstache.go
+++ b/monstache.go
@@ -1923,6 +1923,7 @@ func (config *configOptions) loadIndexTypes() {
 				mapIndexTypes[m.Namespace] = &indexMapping{
 					Namespace: m.Namespace,
 					Index:     strings.ToLower(m.Index),
+					Pipeline:  m.Pipeline
 				}
 			} else {
 				errorLog.Fatalln("Mappings must specify namespace and index")


### PR DESCRIPTION
Hi, I'm currently playing around with Monstache to test if it fits my use-case and it seems to work very well.
Thank you very much for this great application!

Unfortunately, I think I found a bug.

I basically want to have something like this in the `config.toml` file:
```toml
[[mapping]]
namespace = "db.users"
index = "users"
pipeline = "users-ingest-pipeline"
```

But the pipeline isn't sent in the bulk request from Monstache. Looking into the code, I found this place where I think the mapping config is loaded from the toml file and it seems to me that the pipeline is missing there.

Haven't tested it but do you think this might have been forgotten here?

EDIT: tested it now and this change makes it work.